### PR TITLE
Optionally compress binaries with UPX

### DIFF
--- a/scripts/update-tailscale/update-tailscale.sh
+++ b/scripts/update-tailscale/update-tailscale.sh
@@ -140,7 +140,7 @@ compress_binaries() {
     upx_version="$(
         curl -s "https://api.github.com/repos/upx/upx/releases/latest" \
             | grep 'tag_name' \
-            | cut -d : -f 2,3 \
+            | cut -d : -f 2 \
             | tr -d '"v, '
     )"
 


### PR DESCRIPTION
I added a function to compress the binaries with UPX. A few other modifications come from my experience with shellcheck and pre-commit. Please review.

I'm extracting and compressing the binaries one at a time to be considerate about environments where storage space is scarce.

I also created an asciinema recording and a pre-commit configuration which are not part of this PR.